### PR TITLE
Add a way to choose how to encode term to External Term Format

### DIFF
--- a/lib/exos.ex
+++ b/lib/exos.ex
@@ -19,31 +19,31 @@ defmodule Exos.Proc do
   - to allow easy supervision, if the port die with a return code == 0, then
     the GenServer die with the reason `:normal`, else with the reason `:port_terminated`
   """
-  def start_link(cmd,init, opts \\ [],link_opts \\ [],event_fun \\ nil), do:
-    GenServer.start_link(Exos.Proc,{cmd,init,opts,event_fun},link_opts)
+  def start_link(cmd,init, ttb_opts \\ [], opts \\ [],link_opts \\ [],event_fun \\ nil), do:
+    GenServer.start_link(Exos.Proc,{cmd,init,ttb_opts, opts,event_fun},link_opts)
 
-  def init({cmd,initarg,opts}), do: init({cmd,initarg,opts,nil})
-  def init({cmd,initarg,opts,event_fun}) do
-    port = Port.open({:spawn,'#{cmd}'}, [:binary,:exit_status, packet: 4] ++ opts)
+  def init({cmd,initarg,ttb_opts,opts}), do: init({cmd,initarg,ttb_opts,opts,nil})
+  def init({cmd,initarg,ttb_opts,opts,event_fun}) do
+    port = Port.open({:spawn,~c'#{cmd}'}, [:binary,:exit_status, packet: 4] ++ opts)
     if initarg !== :no_init, do:
-      send(port,{self(),{:command,Erl.term_to_binary(initarg)}})
+      send(port,{self(),{:command,Erl.term_to_binary(initarg,ttb_opts)}})
     {:ok,{port,event_fun}}
   end
 
-  def handle_info({port,{:exit_status,0}},{port,_}=state), do: {:stop,:normal,state}
-  def handle_info({port,{:exit_status,_}},{port,_}=state), do: {:stop,:port_terminated,state}
-  def handle_info({port,{:data,b}},{port,event_fun}=state) do
+  def handle_info({port,{:exit_status,0}},{port,_,_}=state), do: {:stop,:normal,state}
+  def handle_info({port,{:exit_status,_}},{port,_,_}=state), do: {:stop,:port_terminated,state}
+  def handle_info({port,{:data,b}},{port,event_fun,_}=state) do
     if event_fun do event_fun.(Erl.binary_to_term(b)) end
     {:noreply,state}
   end
 
-  def handle_cast(term,{port,_}=state) do
-    send(port,{self(),{:command,Erl.term_to_binary(term)}})
+  def handle_cast(term,{port,_,ttb_opts}=state) do
+    send(port,{self(),{:command,Erl.term_to_binary(term,ttb_opts)}})
     {:noreply,state}
   end
 
-  def handle_call(term,_reply_to,{port,_}=state) do
-    send(port,{self(),{:command,Erl.term_to_binary(term)}})
+  def handle_call(term,_reply_to,{port,_,ttb_opts}=state) do
+    send(port,{self(),{:command,Erl.term_to_binary(term,ttb_opts)}})
     res = receive do 
       {^port,{:data,b}}->Erl.binary_to_term(b)
       {^port,{:exit_status,_}}=exit_msg->send(self(),exit_msg);{:error,:port_terminated} # catch exit msg and resend it

--- a/lib/exos.ex
+++ b/lib/exos.ex
@@ -12,38 +12,44 @@ defmodule Exos.Proc do
   - `cmd` is the shell command to launch the port
   - when the port starts, it automatically receives as first message the `init`
     term if `init !== :no_init`
-  - `opts` are options for `Port.open` (for instance `[cd: "/path/"]`)
-  - `link_opts` are options for `GenServer.start_link` (for instance `[name: :servername]`)
+  - `port_opts` are options for `Port.open` (for instance `[cd: "/path/"]`)
+  - `gen_server_opts` are options for `GenServer.start_link` (for instance `[name: :servername]`)
   - messages received from the port outside of a `GenServer.call`
     context trigger a `event_fun.(event)` call if `event_fun` is not `nil` (default)
+  - `etf_opts` are options for `:erlang.term_to_binary` and `:erlang.binary_to_term`
   - to allow easy supervision, if the port die with a return code == 0, then
     the GenServer die with the reason `:normal`, else with the reason `:port_terminated`
   """
-  def start_link(cmd,init, ttb_opts \\ [], opts \\ [],link_opts \\ [],event_fun \\ nil), do:
-    GenServer.start_link(Exos.Proc,{cmd,init,ttb_opts, opts,event_fun},link_opts)
+  def start_link(cmd, init, opts \\ []) do
+    port_opts = Keyword.get(opts, :port_opts, [])
+    gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
+    event_fun = Keyword.get(opts, :event_fun)
+    etf_opts = Keyword.get(opts, :etf_opts, [])
+    GenServer.start_link(Exos.Proc, {cmd, init, port_opts, event_fun, etf_opts}, gen_server_opts)
+  end
 
-  def init({cmd,initarg,ttb_opts,opts}), do: init({cmd,initarg,ttb_opts,opts,nil})
-  def init({cmd,initarg,ttb_opts,opts,event_fun}) do
+  def init({cmd,initarg,opts,etf_opts}), do: init({cmd,initarg,opts,nil,etf_opts})
+  def init({cmd,initarg,opts,event_fun,etf_opts}) do
     port = Port.open({:spawn,~c'#{cmd}'}, [:binary,:exit_status, packet: 4] ++ opts)
     if initarg !== :no_init, do:
-      send(port,{self(),{:command,Erl.term_to_binary(initarg,ttb_opts)}})
-    {:ok,{port,event_fun}}
+      send(port,{self(),{:command,Erl.term_to_binary(initarg,etf_opts)}})
+    {:ok, {port, event_fun, etf_opts}}
   end
 
   def handle_info({port,{:exit_status,0}},{port,_,_}=state), do: {:stop,:normal,state}
   def handle_info({port,{:exit_status,_}},{port,_,_}=state), do: {:stop,:port_terminated,state}
-  def handle_info({port,{:data,b}},{port,event_fun,_}=state) do
-    if event_fun do event_fun.(Erl.binary_to_term(b)) end
+  def handle_info({port,{:data,b}},{port,event_fun,etf_opts}=state) do
+    if event_fun do event_fun.(Erl.binary_to_term(b,etf_opts)) end
     {:noreply,state}
   end
 
-  def handle_cast(term,{port,_,ttb_opts}=state) do
-    send(port,{self(),{:command,Erl.term_to_binary(term,ttb_opts)}})
+  def handle_cast(term,{port,_,etf_opts}=state) do
+    send(port,{self(),{:command,Erl.term_to_binary(term,etf_opts)}})
     {:noreply,state}
   end
 
-  def handle_call(term,_reply_to,{port,_,ttb_opts}=state) do
-    send(port,{self(),{:command,Erl.term_to_binary(term,ttb_opts)}})
+  def handle_call(term,_reply_to,{port,_,etf_opts}=state) do
+    send(port,{self(),{:command,Erl.term_to_binary(term,etf_opts)}})
     res = receive do 
       {^port,{:data,b}}->Erl.binary_to_term(b)
       {^port,{:exit_status,_}}=exit_msg->send(self(),exit_msg);{:error,:port_terminated} # catch exit msg and resend it

--- a/lib/exos.ex
+++ b/lib/exos.ex
@@ -66,8 +66,8 @@ defmodule Exos.Proc do
 
   def handle_info({port,{:exit_status,0}},{port,_,_}=state), do: {:stop,:normal,state}
   def handle_info({port,{:exit_status,_}},{port,_,_}=state), do: {:stop,:port_terminated,state}
-  def handle_info({port,{:data,b}},{port,event_fun,etf_opts}=state) do
-    if event_fun do event_fun.(Erl.binary_to_term(b,etf_opts)) end
+  def handle_info({port,{:data,b}},{port,event_fun,_}=state) do
+    if event_fun do event_fun.(Erl.binary_to_term(b)) end
     {:noreply,state}
   end
 

--- a/lib/exos.ex
+++ b/lib/exos.ex
@@ -20,12 +20,40 @@ defmodule Exos.Proc do
   - to allow easy supervision, if the port die with a return code == 0, then
     the GenServer die with the reason `:normal`, else with the reason `:port_terminated`
   """
+  @deprecated "Use #{__MODULE__}.start_link/3 instead"
+  def start_link(cmd, init, port_opts, gen_server_opts, event_fun) do
+    start_link(cmd, init, [
+      port_opts: port_opts,
+      gen_server_opts: gen_server_opts,
+      event_fun: event_fun,
+    ])
+  end
+
+  @deprecated "Use #{__MODULE__}.start_link/3 instead"
+  def start_link(cmd, init, port_opts, gen_server_opts) do
+    start_link(cmd, init, [
+      port_opts: port_opts,
+      gen_server_opts: gen_server_opts,
+    ])
+  end
+
   def start_link(cmd, init, opts \\ []) do
-    port_opts = Keyword.get(opts, :port_opts, [])
-    gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
-    event_fun = Keyword.get(opts, :event_fun)
-    etf_opts = Keyword.get(opts, :etf_opts, [])
-    GenServer.start_link(Exos.Proc, {cmd, init, port_opts, event_fun, etf_opts}, gen_server_opts)
+    known_opts = [:port_opts, :gen_server_opts, :event_fun, :etf_opts]
+    case Keyword.keyword?(opts) and match?({:ok, _}, Keyword.validate(opts, known_opts)) do
+      true ->
+        port_opts = Keyword.get(opts, :port_opts, [])
+        gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
+        event_fun = Keyword.get(opts, :event_fun)
+        etf_opts = Keyword.get(opts, :etf_opts, [])
+        GenServer.start_link(Exos.Proc, {cmd, init, port_opts, event_fun, etf_opts}, gen_server_opts)
+
+      false ->
+        # If no key matches with our opts, then it means it is the old API being used.
+        IO.warn("You are using the old API of #{__MODULE__}.start_link/3 that takes Port.open/2
+          options as 3rd parameter. The new API takes a Keyword list instead to handle options of
+          the old API.")
+        start_link(cmd, init, [port_opts: opts])
+    end
   end
 
   def init({cmd,initarg,opts,etf_opts}), do: init({cmd,initarg,opts,nil,etf_opts})

--- a/test/exos_test.exs
+++ b/test/exos_test.exs
@@ -13,7 +13,11 @@ defmodule ExosTest do
 
   setup_all do
     Registry.start_link(keys: :duplicate, name: TestEvents)
-    Exos.Proc.start_link("elixir --erl -noinput #{__DIR__}/port_example.exs",0,[],[name: EchoAndAccount],&dispatch_event/1)
+    Exos.Proc.start_link(
+      "elixir --erl -noinput #{__DIR__}/port_example.exs",
+      0,
+      gen_server_opts: [name: EchoAndAccount],
+      event_fun: &dispatch_event/1)
     :ok
   end
 

--- a/test/exos_test.exs
+++ b/test/exos_test.exs
@@ -1,6 +1,8 @@
 defmodule ExosTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   @dispatch_key :events
   def dispatch_event(event) do
     Registry.dispatch(TestEvents, @dispatch_key, fn entries ->
@@ -11,40 +13,50 @@ defmodule ExosTest do
     {:ok, _} = Registry.register(TestEvents,@dispatch_key,nil)
   end
 
-  setup_all do
-    Registry.start_link(keys: :duplicate, name: TestEvents)
-    Exos.Proc.start_link(
-      "elixir --erl -noinput #{__DIR__}/port_example.exs",
-      0,
-      gen_server_opts: [name: EchoAndAccount],
-      event_fun: &dispatch_event/1)
-    :ok
-  end
-
-  test "Echo call to port" do
-    assert {:foo,:bar} = GenServer.call(EchoAndAccount,{:echo,{:foo,:bar}})
-  end
-
-  test "Account state management, cast and call" do
-    GenServer.cast(EchoAndAccount,{:add,2})
-    GenServer.cast(EchoAndAccount,{:add,4})
-    GenServer.cast(EchoAndAccount,{:rem,1})
-    assert 5 = GenServer.call(EchoAndAccount,:counter)
-  end
-
-  test "Test event management" do
-    defmodule TestHandler do #put last event in state
-      use GenServer
-      def init(_) do ExosTest.register!(); {:ok,[]} end
-      def handle_info({:event,event},_) do {:noreply, event} end
-      def handle_call(:last,_,last) do {:reply,last,last} end
+  describe "Backward compatibility tests" do
+    test "Old start_link/3 API" do
+      assert capture_io(:stderr, fn ->
+        Exos.Proc.start_link("elixir --erl -noinput #{__DIR__}/port_example.exs", 0, [:eof])
+      end) != ""
     end
-    GenServer.start_link(TestHandler,[], name: TestHandler)
-    GenServer.cast(EchoAndAccount,{:echo,{:hello,:world}})
-    receive do after 1000->:ok end
-    assert {:hello,:world} = GenServer.call(TestHandler,:last)
-    GenServer.cast(EchoAndAccount,{:echo,{:hello,:arnaud}})
-    receive do after 1000->:ok end
-    assert {:hello,:arnaud} = GenServer.call(TestHandler,:last)
+  end
+
+  describe "Functional tests" do
+    setup do
+      Registry.start_link(keys: :duplicate, name: TestEvents)
+      Exos.Proc.start_link(
+        "elixir --erl -noinput #{__DIR__}/port_example.exs",
+        0,
+        gen_server_opts: [name: EchoAndAccount],
+        event_fun: &dispatch_event/1)
+      :ok
+    end
+
+    test "Echo call to port" do
+      assert {:foo,:bar} = GenServer.call(EchoAndAccount,{:echo,{:foo,:bar}})
+    end
+
+    test "Account state management, cast and call" do
+      GenServer.cast(EchoAndAccount,{:add,2})
+      GenServer.cast(EchoAndAccount,{:add,4})
+      GenServer.cast(EchoAndAccount,{:rem,1})
+      assert 5 = GenServer.call(EchoAndAccount,:counter)
+    end
+
+    test "Test event management" do
+      defmodule TestHandler do #put last event in state
+        use GenServer
+        def init(_) do ExosTest.register!(); {:ok,[]} end
+        def handle_info({:event,event},_) do {:noreply, event} end
+        def handle_call(:last,_,last) do {:reply,last,last} end
+      end
+      GenServer.start_link(TestHandler,[], name: TestHandler)
+      GenServer.cast(EchoAndAccount,{:echo,{:hello,:world}})
+      receive do after 1000->:ok end
+      assert {:hello,:world} = GenServer.call(TestHandler,:last)
+      GenServer.cast(EchoAndAccount,{:echo,{:hello,:arnaud}})
+      receive do after 1000->:ok end
+      assert {:hello,:arnaud} = GenServer.call(TestHandler,:last)
+    end
   end
 end


### PR DESCRIPTION
With OTP 26 the function `:erlang.term_to_binary` changes what it outputs.
To avoid breaking changes for library using exos, it is now possible to give options to the function `erlang.term_to_binary/2` so it outputs value it does before OTP 26